### PR TITLE
Add G8188 to Xperia XZ Premium

### DIFF
--- a/G81XX/G81XX.properties
+++ b/G81XX/G81XX.properties
@@ -2,8 +2,8 @@
 internalname=G81XX
 canfastboot=true
 busyboxhelper=1.20.2
-recognition=G8142,G8141,SO-04J
-variant=G8142,G8141,SO-04J
+recognition=G8142,G8141,G8188,SO-04J
+variant=G8142,G8141,G8188,SO-04J
 cankernel=false
 busyboxinstallpath=/system/xbin
 loader_unlocked=


### PR DESCRIPTION
G8188 is unlocked (and bootloader unlockable) XZ Premium for Japanese market.