### PR TITLE
Update and rename SO-52B.properties to SO-52B.properties

### DIFF
--- a/XQ-BT/SO-52B.properties
+++ b/XQ-BT/SO-52B.properties
@@ -1,14 +1,14 @@
-#Fri Aug 08 18:46:20 CEST 2014
-internalname=XQ-BT
+#Fri Aug 08 18:46:20 CEST 2022
+internalname=SO-52B
 canfastboot=true
 busyboxhelper=1.20.2
-recognition=XQ-BT52
-variant=XQ-BT52
+recognition=SO-52B
+variant=SO-52B
 cankernel=false
 busyboxinstallpath=/system/xbin
-loader_unlocked=
+loader_unlocked=SO-52B
 realname=Sony Xperia 10 III
-loader=
+loader=SO-52B
 canrecovery=false
 buildprop=ro.product.device
 canflash=true


### PR DESCRIPTION
#Fri Aug 08 18:46:20 CEST 2014
internalname=SO-52B
canfastboot=true
busyboxhelper=1.20.2
recognition=SO-52B
variant=SO-52B
cankernel=false
busyboxinstallpath=/system/xbin
loader_unlocked=
realname=Sony Xperia 10 III
loader=
canrecovery=false
buildprop=ro.product.device
canflash=true
fscmandatory=true
flashProtocol=Command