### PR TITLE
Create SONY10III

### DIFF
--- a/SONY10III
+++ b/SONY10III
@@ -1,0 +1,16 @@
+#Fri Aug 08 18:46:20 CEST 2014
+internalname=SO-52B
+canfastboot=true
+busyboxhelper=1.20.2
+recognition=SO-52B
+variant=SO-52B
+cankernel=false
+busyboxinstallpath=/system/xbin
+loader_unlocked=
+realname=Sony Xperia 10 III
+loader=
+canrecovery=false
+buildprop=ro.product.device
+canflash=true
+fscmandatory=true
+flashProtocol=Command


### PR DESCRIPTION
#Fri Aug 08 18:46:20 CEST 2014
internalname=SO-52B
canfastboot=true
busyboxhelper=1.20.2
recognition=SO-52B
variant=SO-52B
cankernel=false
busyboxinstallpath=/system/xbin
loader_unlocked=
realname=Sony Xperia 10 III
loader=
canrecovery=false
buildprop=ro.product.device
canflash=true
fscmandatory=true
flashProtocol=Command